### PR TITLE
docs: update Claude hook examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,13 @@ This program integrates with Claude Code's notification system through the hooks
   "hooks": {
     "Notification": [
       {
-        "type": "command",
-        "command": "claude-code-notification"
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "claude-code-notification"
+          }
+        ]
       }
     ]
   }
@@ -58,8 +63,13 @@ This program integrates with Claude Code's notification system through the hooks
   "hooks": {
     "Notification": [
       {
-        "type": "command", 
-        "command": "claude-code-notification --sound Submarine"
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "claude-code-notification --sound Submarine"
+          }
+        ]
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ Configure in your Claude Code settings:
   "hooks": {
     "Notification": [
       {
-        "type": "command",
-        "command": "claude-code-notification"
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "claude-code-notification"
+          }
+        ]
       }
     ]
   }
@@ -51,13 +56,20 @@ Configure in your Claude Code settings:
   "hooks": {
     "Notification": [
       {
-        "type": "command",
-        "command": "claude-code-notification --sound Submarine"
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "claude-code-notification --sound Submarine"
+          }
+        ]
       }
     ]
   }
 }
 ```
+
+The `matcher` field can be left empty to fire on all notification events, or set to a specific event type (e.g. `permission_prompt`, `idle_prompt`, `auth_success`). See the [Claude Code hooks documentation](https://code.claude.com/docs/en/hooks) for the full list of matchers.
 
 ## Configuration
 


### PR DESCRIPTION
## What
- Update Claude Code notification hook examples to use the matcher plus nested hooks schema.
- Add a README note pointing readers to Claude Code hook matcher documentation.

## Why
The documentation should reflect the current Claude Code hook configuration shape for notification commands.

## Testing
Docs-only change. Verified with `git diff --check`.
